### PR TITLE
Moved mappings to top of contract for readability

### DIFF
--- a/Contracts/DevCash.sol
+++ b/Contracts/DevCash.sol
@@ -63,6 +63,9 @@ contract DevCash is EIP20Interface {
     uint8 public decimals;
     string public symbol;
 
+    mapping (address => uint256) balances;
+    mapping (address => mapping (address => uint256)) allowed;
+
      function DevCash(
 
         ) public {
@@ -108,6 +111,4 @@ contract DevCash is EIP20Interface {
       return allowed[_owner][_spender];
     }
 
-    mapping (address => uint256) balances;
-    mapping (address => mapping (address => uint256)) allowed;
 }


### PR DESCRIPTION
I just think keeping variables and data structures before contract functions helps with readability.